### PR TITLE
fix(generateQuery): replace count() with isset() and remove jsno_encode()

### DIFF
--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * Utility/Helper where all the helper and utility functions will be available.
- * 
+ *
  * PHP version 5
- * 
+ *
  * @category  PHP
  * @package   Contentstack
  * @author    Uttam K Ukkoji <uttamukkoji@gmail.com>
@@ -22,7 +22,7 @@ use Contentstack\Result\Result;
 
 /**
  * Utility/Helper where all the helper and utility functions will be available.
- * 
+ *
  * @category  PHP
  * @package   Contentstack
  * @author    Uttam K Ukkoji <uttamukkoji@gmail.com>
@@ -35,10 +35,10 @@ class Utility
 {
     /**
      * Validation for all the parameters required for the SDK
-     * 
+     *
      * @param string $type  - type of the value to be validated
      * @param object $input - value of the respective type
-     * 
+     *
      * @return array
      * */
     public static function validateInput($type = '', $input = array())
@@ -46,51 +46,51 @@ class Utility
         $msg = '';
         try {
             switch ($type) {
-            case 'stack' :
-                if ($input['region']) {
-                    if (!(Utility::isKeySet($input, 'api_key') 
-                        && Utility::isKeySet($input, 'access_token') 
-                        && Utility::isKeySet($input, 'environment') 
-                        && Utility::isKeySet($input, 'region'))
-                    ) {
-                        $msg = 'Please provide valid api_key, 
+                case 'stack' :
+                    if ($input['region']) {
+                        if (!(Utility::isKeySet($input, 'api_key')
+                            && Utility::isKeySet($input, 'access_token')
+                            && Utility::isKeySet($input, 'environment')
+                            && Utility::isKeySet($input, 'region'))
+                        ) {
+                            $msg = 'Please provide valid api_key, 
                             access_token, 
                             environment and region';
-                    }
-                    break;
-                } else {
-                    if (!(Utility::isKeySet($input, 'api_key') 
-                        && Utility::isKeySet($input, 'access_token') 
-                        && Utility::isKeySet($input, 'environment'))
-                    ) {
-                        $msg = 'Please provide valid api_key, 
+                        }
+                        break;
+                    } else {
+                        if (!(Utility::isKeySet($input, 'api_key')
+                            && Utility::isKeySet($input, 'access_token')
+                            && Utility::isKeySet($input, 'environment'))
+                        ) {
+                            $msg = 'Please provide valid api_key, 
                         access_token and environment';
+                        }
+                        break;
+                    }
+
+                case 'port' :
+                    if (Utility::isEmpty($input) || !is_numeric($input)) {
+                        $msg = 'Please provide valid string for '.$type;
                     }
                     break;
-                }
-
-            case 'port' :
-                if (Utility::isEmpty($input) || !is_numeric($input)) {
-                    $msg = 'Please provide valid string for '.$type;
-                }
-                break;
-            case 'protocol' :
-                if (Utility::isEmpty($input) 
-                    || !is_string($input) 
-                    || !array_search($input, array('http', 'https'))
-                ) {
-                    $msg = 'Please provide valid string for '
-                    .$type.' And it should be either http or https';
-                }
-                break;
-            case 'host' :
-            case 'access_token' :
-            case 'environment' :
-            case 'api_key' :
-                if (Utility::isEmpty($input) || !is_string($input)) {
-                    $msg = 'Please provide valid string for '.$type;
-                }
-                break;
+                case 'protocol' :
+                    if (Utility::isEmpty($input)
+                        || !is_string($input)
+                        || !array_search($input, array('http', 'https'))
+                    ) {
+                        $msg = 'Please provide valid string for '
+                            .$type.' And it should be either http or https';
+                    }
+                    break;
+                case 'host' :
+                case 'access_token' :
+                case 'environment' :
+                case 'api_key' :
+                    if (Utility::isEmpty($input) || !is_string($input)) {
+                        $msg = 'Please provide valid string for '.$type;
+                    }
+                    break;
             }
             if (!Utility::isEmpty($msg)) {
                 throw new \Exception($msg);
@@ -103,16 +103,16 @@ class Utility
     }
     /**
      * Get the domain from the current object
-     * 
+     *
      * @param Stack $query - Instance of S.tack
-     * 
+     *
      * @return String
      * */
     public static function getDomain($query)
     {
-        $stack = $query;  
-        if ($query && isset($query->contentType)) { 
-            $stack = $query->contentType->stack; 
+        $stack = $query;
+        if ($query && isset($query->contentType)) {
+            $stack = $query->contentType->stack;
         }
         if ($query && isset($query->stack)) {
             $stack = $query->stack;
@@ -128,40 +128,40 @@ class Utility
 
     /**
      * Contentstack URL method to create the url based on the request
-     * 
+     *
      * @param object $queryObject - Query Object
      * @param string $type        - type for url
-     * 
+     *
      * @return string
      * */
     public static function contentstackUrl($queryObject = '', $type = '')
     {
         $URL = '';
         switch ($type) {
-        case 'set_environment':
-            $URL = Utility::getDomain($queryObject).ENVIRONMENTS.''
-            .$queryObject->contentType->stack->getEnvironment();
-            break;
-        case 'get_last_activites':
-            $URL = Utility::getDomain($queryObject).CONTENT_TYPES;
-            break;
-        case 'getcontentTypes':
-            $URL = Utility::getDomain($queryObject).CONTENT_TYPES;
-            break;    
-        case 'asset':
-            $URL = Utility::getDomain($queryObject).ASSETS.$queryObject->assetUid;
-            break;
-        case 'assets':
-            $URL = Utility::getDomain($queryObject).ASSETS;
-            break;                      
-        default:
-            $URL = Utility::getDomain($queryObject).CONTENT_TYPES
-            .$queryObject->contentType->uid.ENTRIES;
-            if (isset($queryObject->entryUid)) {
-                $URL.=$queryObject->entryUid;
-            }
+            case 'set_environment':
+                $URL = Utility::getDomain($queryObject).ENVIRONMENTS.''
+                    .$queryObject->contentType->stack->getEnvironment();
+                break;
+            case 'get_last_activites':
+                $URL = Utility::getDomain($queryObject).CONTENT_TYPES;
+                break;
+            case 'getcontentTypes':
+                $URL = Utility::getDomain($queryObject).CONTENT_TYPES;
+                break;
+            case 'asset':
+                $URL = Utility::getDomain($queryObject).ASSETS.$queryObject->assetUid;
+                break;
+            case 'assets':
+                $URL = Utility::getDomain($queryObject).ASSETS;
+                break;
+            default:
+                $URL = Utility::getDomain($queryObject).CONTENT_TYPES
+                    .$queryObject->contentType->uid.ENTRIES;
+                if (isset($queryObject->entryUid)) {
+                    $URL.=$queryObject->entryUid;
+                }
         }
-        
+
         $queryParams = Utility::generateQueryParams($queryObject);
         return $URL.'?'.$queryParams;
 
@@ -169,9 +169,9 @@ class Utility
 
     /**
      * Header transformation as it required format
-     * 
+     *
      * @param array $query - input headers in key value pair
-     * 
+     *
      * @return array
      * */
     public static function headers($query = '')
@@ -193,9 +193,9 @@ class Utility
 
     /**
      * POST formatted query for the API server
-     * 
+     *
      * @param array $query - Query array
-     * 
+     *
      * @return json
      * */
     public static function generateQuery($query = array())
@@ -205,8 +205,8 @@ class Utility
             $query->_query['environment'] = $query->contentType
                 ->stack->getEnvironment();
             $subQuery = array();
-            if (count($query->subQuery) > 0) {
-                $subQuery['query'] = json_encode($query->subQuery);
+            if (isset($query->subQuery)) {
+                $subQuery['query'] = $query->subQuery;
             }
 
             $include_schema = array_search(
@@ -214,13 +214,13 @@ class Utility
                 array_keys($query->_query)
             );
             $include_content_type = array_search(
-                'include_content_type', 
+                'include_content_type',
                 array_keys($query->_query)
             );
 
             if ($include_schema < $include_content_type) {
                 foreach ($query->_query as $key => $value) {
-                    if ($key == 'include_schema') { 
+                    if ($key == 'include_schema') {
                         unset($query->_query['include_schema']);
                         $query->_query["include_schema"] = "true";
                     }
@@ -228,7 +228,7 @@ class Utility
             }
 
             $result = array_merge($query->_query, $subQuery);
-        } elseif (isset($query->stack)) {       
+        } elseif (isset($query->stack)) {
             $query->_query['environment'] = $query->stack->getEnvironment();
             $result = array_merge($result, $query->_query);
 
@@ -248,9 +248,9 @@ class Utility
 
     /**
      * Sending the GET requests with all the parameters in POST as well as GET
-     * 
+     *
      * @param array $query - Query array
-     * 
+     *
      * @return QueryParameters
      * */
     public static function generateQueryParams($query = array())
@@ -261,7 +261,7 @@ class Utility
 
     /**
      * Wrap Result
-     * 
+     *
      * @param object $result      - Response content
      * @param object $queryObject - Query object
      *
@@ -269,104 +269,104 @@ class Utility
      * */
     public static function wrapResult($result = '', $queryObject = '')
     {
-        $result = $wrapper = json_decode($result, true);            
+        $result = $wrapper = json_decode($result, true);
         if ($result && $queryObject && isset($queryObject->operation)) {
-            $flag =  (isset($queryObject->json_translate) 
-            && $queryObject->json_translate);
+            $flag =  (isset($queryObject->json_translate)
+                && $queryObject->json_translate);
             switch ($queryObject->operation) {
-            case 'findOne':
-                if (Utility::isKeySet($result, 'entries') 
-                    && count($result['entries']) > 0
-                ) {
-                    $wrapper = ($flag) ? $result['entries'][0] : 
-                        new Result(
-                            $result['entries'][0]
+                case 'findOne':
+                    if (Utility::isKeySet($result, 'entries')
+                        && count($result['entries']) > 0
+                    ) {
+                        $wrapper = ($flag) ? $result['entries'][0] :
+                            new Result(
+                                $result['entries'][0]
+                            );
+                    } else {
+                        $wrapper = json_encode(
+                            array(
+                                "error_code" => 119,
+                                "error_message" => "The requested entry doesn't exists"
+                            )
                         );
-                } else {
-                    $wrapper = json_encode(
-                        array(
-                            "error_code" => 119, 
-                            "error_message" => "The requested entry doesn't exists"
-                        )
-                    );
-                }
-                break;
-            case 'fetch':
-                if (Utility::isKeySet($result, 'entry')) {
-                    $wrapper = (!$flag) ? 
-                    new Result(
-                        $result['entry']
-                    ) 
-                    : $result['entry'];
-                } elseif (Utility::isKeySet($result, 'asset')) {
-                    $wrapper = (!$flag) ? 
-                    new Result(
-                        $result['asset']
-                    ) 
-                    : $result['asset'];
-                } elseif (Utility::isKeySet($result, 'schema')) {
-                    array_push($wrapper, $result['schema']);
-                } elseif (Utility::isKeySet($result, 'content_type')) {
-                    array_push($wrapper, $result['content_type']);  
-                }  
-                break;
-            case 'find':
-                $wrapper = array();
-                if (Utility::isKeySet($result, 'entries')) {
-                    if (!is_numeric($result['entries'])) {
-                        for ($i = 0, 
-                            $_i = count($result['entries']); 
-                            $i < $_i && !$flag; $i++) {
-                            $result['entries'][$i] = new Result(
-                                $result['entries'][$i]
-                            );
-                        }
                     }
-                    array_push($wrapper, $result['entries']);
-                }
-                if (Utility::isKeySet($result, 'assets')) {
-                    if (!is_numeric($result['assets'])) {
-                        for ($i = 0, 
-                            $_i = count($result['assets']); 
-                            $i < $_i && !$flag; $i++
-                        ) {
-                            $result['assets'][$i] = new Result(
-                                $result['assets'][$i]
-                            );
+                    break;
+                case 'fetch':
+                    if (Utility::isKeySet($result, 'entry')) {
+                        $wrapper = (!$flag) ?
+                            new Result(
+                                $result['entry']
+                            )
+                            : $result['entry'];
+                    } elseif (Utility::isKeySet($result, 'asset')) {
+                        $wrapper = (!$flag) ?
+                            new Result(
+                                $result['asset']
+                            )
+                            : $result['asset'];
+                    } elseif (Utility::isKeySet($result, 'schema')) {
+                        array_push($wrapper, $result['schema']);
+                    } elseif (Utility::isKeySet($result, 'content_type')) {
+                        array_push($wrapper, $result['content_type']);
+                    }
+                    break;
+                case 'find':
+                    $wrapper = array();
+                    if (Utility::isKeySet($result, 'entries')) {
+                        if (!is_numeric($result['entries'])) {
+                            for ($i = 0,
+                                 $_i = count($result['entries']);
+                                 $i < $_i && !$flag; $i++) {
+                                $result['entries'][$i] = new Result(
+                                    $result['entries'][$i]
+                                );
+                            }
                         }
-                    } 
-                    array_push($wrapper, $result['assets']);    
-                }
-            
-                if (Utility::isKeySet($result, 'schema')) {
-                    array_push($wrapper, $result['schema']);
-                }
-                if (Utility::isKeySet($result, 'content_type')) {
-                    array_push($wrapper, $result['content_type']);
-                }
-                if (Utility::isKeySet($result, 'count')) {
-                    array_push($wrapper, $result['count']);
-                }
-                break;
+                        array_push($wrapper, $result['entries']);
+                    }
+                    if (Utility::isKeySet($result, 'assets')) {
+                        if (!is_numeric($result['assets'])) {
+                            for ($i = 0,
+                                 $_i = count($result['assets']);
+                                 $i < $_i && !$flag; $i++
+                            ) {
+                                $result['assets'][$i] = new Result(
+                                    $result['assets'][$i]
+                                );
+                            }
+                        }
+                        array_push($wrapper, $result['assets']);
+                    }
+
+                    if (Utility::isKeySet($result, 'schema')) {
+                        array_push($wrapper, $result['schema']);
+                    }
+                    if (Utility::isKeySet($result, 'content_type')) {
+                        array_push($wrapper, $result['content_type']);
+                    }
+                    if (Utility::isKeySet($result, 'count')) {
+                        array_push($wrapper, $result['count']);
+                    }
+                    break;
             }
         }
         return $wrapper;
     }
-    
+
     /**
      * Contentstack request to the API server based on the data
-     * 
+     *
      * @param object $queryObject - Query Object
      * @param object $type        - type of request
-     * 
+     *
      * @return Result
      * */
     public static function contentstackRequest($queryObject = '', $type = '')
     {
         $server_output = '';
-        
+
         if ($queryObject) {
-            $http = curl_init(Utility::contentstackUrl($queryObject, $type));  
+            $http = curl_init(Utility::contentstackUrl($queryObject, $type));
 
             // setting the HTTP Headers
             $Headers     = Utility::headers($queryObject);
@@ -376,7 +376,7 @@ class Utility
             $request_headers[] = 'api_key: '.$Headers["api_key"];
             $request_headers[] = 'access_token: '.$Headers["access_token"];
             curl_setopt($http, CURLOPT_HTTPHEADER, $request_headers);
-            
+
             curl_setopt($http, CURLOPT_HEADER, false);
             // setting the GET request
             curl_setopt($http, CURLOPT_CUSTOMREQUEST, "GET");
@@ -387,11 +387,11 @@ class Utility
             // status code extraction
             $httpcode = curl_getinfo($http, CURLINFO_HTTP_CODE);
 
-            // close the curl            
+            // close the curl
             curl_close($http);
             if ($httpcode > 199 && $httpcode < 300) {
                 // wrapper the server result
-                $response = Utility::wrapResult($response, $queryObject);            
+                $response = Utility::wrapResult($response, $queryObject);
             } else {
                 throw new CSException($response, $httpcode);
             }
@@ -401,10 +401,10 @@ class Utility
 
     /**
      * Validate the key is set or not
-     * 
-     * @param array  $input - input 
+     *
+     * @param array  $input - input
      * @param string $key   - key to check
-     * 
+     *
      * @return boolean
      * */
     public static function isKeySet($input = array(), $key = '')
@@ -414,42 +414,42 @@ class Utility
 
     /**
      * Validate the String
-     * 
+     *
      * @param object $input - object to check for empty
-     * 
+     *
      * @return boolean
      * */
-    public static function isEmpty($input) 
+    public static function isEmpty($input)
     {
         return (empty($input));
     }
 
     /**
      * Get Last activities
-     * 
+     *
      * @param object $queryObject - query object
-     * 
+     *
      * @return object
      * */
-    public static function getLastActivites($queryObject) 
+    public static function getLastActivites($queryObject)
     {
         return request($queryObject, 'get_last_activites');
     }
 
     /**
      * DEBUGGING MESSAGE
-     * 
+     *
      * @param object  $input - object to debug
      * @param boolean $exit  - to exit on debug
-     * 
+     *
      * @return object
      * */
     public static function debug($input, $exit = false)
     {
         echo "<pre>";
-            print_r($input);
+        print_r($input);
         echo "</pre>";
-        if ($exit) { 
+        if ($exit) {
             exit();
         }
     }


### PR DESCRIPTION
`if (count($query->subQuery) > 0) {
                $subQuery['query'] = json_encode($query->subQuery);
            }`

count() had a breaking change in PHP >=7.2 and cannot be used anymore on strings ($query->subQuery). Therefore I am replacing it with isset() which will also work for older versions of PHP.
I am also removing the json_encode function because as mentioned previously `$query->subQuery` is already a string.