### PR TITLE
fix(generateQuery):  replace count() with isset() and remove json_encode call on ->subQuery

### DIFF
--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -205,8 +205,8 @@ class Utility
             $query->_query['environment'] = $query->contentType
                 ->stack->getEnvironment();
             $subQuery = array();
-            if (isset($query->subQuery)) {
-                $subQuery['query'] = $query->subQuery;
+            if (count($query->subQuery) > 0) {
+                $subQuery['query'] = json_encode($query->subQuery);
             }
 
             $include_schema = array_search(

--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -205,8 +205,8 @@ class Utility
             $query->_query['environment'] = $query->contentType
                 ->stack->getEnvironment();
             $subQuery = array();
-            if (count($query->subQuery) > 0) {
-                $subQuery['query'] = json_encode($query->subQuery);
+            if (isset($query->subQuery)) {
+                $subQuery['query'] = $query->subQuery;
             }
 
             $include_schema = array_search(

--- a/src/lib/models/base_query.php
+++ b/src/lib/models/base_query.php
@@ -676,7 +676,7 @@ abstract class BaseQuery
     public function addQuery($_query = array()) 
     {
         if ($_query && is_array($_query)) {
-            $this->subQuery = json_encode($_query);
+            $this->subQuery = $_query;
             return $this->queryObject;
         }
         throw contentstackCreateError("Provide valid query");

--- a/src/lib/models/base_query.php
+++ b/src/lib/models/base_query.php
@@ -128,7 +128,7 @@ abstract class BaseQuery
      * */
     public function includeReference($field_uids = array()) 
     {
-        if ($field_uids && is_array($field_uids)) {
+        if (is_array($field_uids)) {
             $this->queryObject->_query = call_user_func(
                 'contentstackReferences', 
                 'include', 
@@ -465,7 +465,7 @@ abstract class BaseQuery
      * */
     public function tags($tags = array()) 
     {
-        if ($tags && is_array($tags)) {
+        if (is_array($tags)) {
             $this->queryObject->_query = call_user_func(
                 'contentstackTags', 
                 'tags', 
@@ -508,7 +508,7 @@ abstract class BaseQuery
      * */
     public function containedIn($field = '', $value = array()) 
     {
-        if ($value && is_array($value)) {
+        if (is_array($value)) {
             $this->subQuery = call_user_func(
                 'contentstackContains', 
                 '$in', 
@@ -533,7 +533,7 @@ abstract class BaseQuery
      * */
     public function notContainedIn($field = '', $value = array()) 
     {
-        if ($value && is_array($value)) {
+        if (is_array($value)) {
             $this->subQuery = call_user_func(
                 'contentstackContains', 
                 '$nin',
@@ -675,7 +675,7 @@ abstract class BaseQuery
      * */
     public function addQuery($_query = array()) 
     {
-        if ($_query && is_array($_query)) {
+        if (is_array($_query)) {
             $this->subQuery = $_query;
             return $this->queryObject;
         }


### PR DESCRIPTION
`if (count($query->subQuery) > 0) { $subQuery['query'] = json_encode($query->subQuery); }`

count() had a breaking change in PHP >=7.2 and cannot be used anymore on strings ($query->subQuery). Therefore I am replacing it with isset() which will also work for older versions of PHP.
I am also removing the json_encode function because as mentioned previously `$query->subQuery` is already a string.