### PR TITLE
Fixed Live Preview | Extra key word entry for the reference field bre…

### DIFF
--- a/src/Support/Utility.php
+++ b/src/Support/Utility.php
@@ -465,8 +465,13 @@ class Utility
                 {
                     $entry_uid = $queryObject->entryUid;
                     $content_type_uid = $queryObject->contentType->uid;
-                    $live_response_decode = json_decode($response, true);
-
+                    $response_decode = json_decode($response, true);
+                    if (Utility::isKeySet($response_decode, 'entry')) {
+                        $live_response_decode = $response_decode['entry'];
+                    }
+                    else{
+                        $live_response_decode = $response_decode;
+                    }
                 }
                     // wrapper the server result
                     $response = Utility::wrapResult($response, $queryObject);  


### PR DESCRIPTION
…aks the live preview

Live Preview | Extra key word entry for the reference field breaks the live preview. Changed the response format.
{
  title: "some title",
  "reference": {
    // the reference data
  }
}