### PR TITLE
Added support for endpoint integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/result.json
 stdout
 build
 cache
+src/assets/regions.json

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,11 @@
         "code-lts/doctum": "^5.3"
     },
     "scripts": {
+        "post-install-cmd": ["@php scripts/download-regions.php"],
+        "post-update-cmd":  ["@php scripts/download-regions.php"],
         "generate:docs": "vendor/bin/doctum.php update ./config.php",
-        "test": "vendor/bin/phpunit"
+        "test": "vendor/bin/phpunit",
+        "refresh-regions": "@php scripts/download-regions.php"
     },
     "require": {
         "php" : ">=5.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -146,26 +146,26 @@
     "packages-dev": [
         {
             "name": "code-lts/cli-tools",
-            "version": "v1.6.0",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/code-lts/cli-tools.git",
-                "reference": "399bb23041a3d3d9dbf340f5c7c6ceb129fc65ae"
+                "reference": "d4e4f00060468b34c129f4a5424171b4a43a9d82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/code-lts/cli-tools/zipball/399bb23041a3d3d9dbf340f5c7c6ceb129fc65ae",
-                "reference": "399bb23041a3d3d9dbf340f5c7c6ceb129fc65ae",
+                "url": "https://api.github.com/repos/code-lts/cli-tools/zipball/d4e4f00060468b34c129f4a5424171b4a43a9d82",
+                "reference": "d4e4f00060468b34c129f4a5424171b4a43a9d82",
                 "shasum": ""
             },
             "require": {
                 "ondram/ci-detector": "^4.0",
-                "php": "^7.2 || ^8.0",
-                "symfony/console": "^5 || ^6 || ^7"
+                "php": "^8.1",
+                "symfony/console": "^6.4.27 || ^7.3 || ^8"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.4.6",
-                "phpunit/phpunit": "^8 || ^9 || ^10|| ^11",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^10.5.60 || ^11 || ^12.4",
                 "wdes/coding-standard": "^3.2"
             },
             "type": "library",
@@ -206,42 +206,42 @@
                 "issues": "https://github.com/code-lts/cli-tools/issues",
                 "source": "https://github.com/code-lts/cli-tools"
             },
-            "time": "2024-08-20T10:39:29+00:00"
+            "time": "2026-01-22T09:28:58+00:00"
         },
         {
             "name": "code-lts/doctum",
-            "version": "v5.5.4",
+            "version": "v5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/code-lts/doctum.git",
-                "reference": "fbece8ccb38b863b487672ce19f40081c0a75655"
+                "reference": "fc3cd98ab569f8ad3f060010a2f627c1777409bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/code-lts/doctum/zipball/fbece8ccb38b863b487672ce19f40081c0a75655",
-                "reference": "fbece8ccb38b863b487672ce19f40081c0a75655",
+                "url": "https://api.github.com/repos/code-lts/doctum/zipball/fc3cd98ab569f8ad3f060010a2f627c1777409bf",
+                "reference": "fc3cd98ab569f8ad3f060010a2f627c1777409bf",
                 "shasum": ""
             },
             "require": {
-                "code-lts/cli-tools": "^1.4.0",
-                "erusev/parsedown": "^1.7",
-                "nikic/php-parser": "^4.10",
-                "php": "^7.2.20 || ^8.0",
-                "phpdocumentor/reflection-docblock": "~5.3",
-                "phpdocumentor/type-resolver": "1.6.*",
-                "symfony/console": "~3.4|~4.3|^5|^6",
-                "symfony/filesystem": "~3.4|~4.3|^5|^6",
-                "symfony/finder": "~3.4|~4.3|^5|^6",
-                "symfony/process": "~3.4|~4.3|^5|^6",
-                "symfony/yaml": "~3.4|~4.3|^5|^6",
-                "twig/twig": "^3.0",
-                "wdes/php-i18n-l10n": "^4.0"
+                "code-lts/cli-tools": "^1.7",
+                "nikic/php-parser": "^5.6.2",
+                "parsedown/parsedown": "^1.7.5",
+                "php": "^8.1",
+                "phpdocumentor/reflection-docblock": "^6.0.1",
+                "symfony/console": "^6.4.27||^7.3||^8",
+                "symfony/filesystem": "^6.4.24||^7.3||^8",
+                "symfony/finder": "^6.4.27||^7.3||^8",
+                "symfony/process": "^6.4.26||^7.3||^8",
+                "symfony/string": "^6.4.26||^7.3||^8",
+                "symfony/yaml": "^6.4.26||^7.3||^8",
+                "twig/twig": "^3.22",
+                "wdes/php-i18n-l10n": "^4.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.4.6",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7 || ^8 || ^9",
-                "wdes/coding-standard": "^3.3.1"
+                "phpstan/phpstan": "^2.1.36",
+                "phpstan/phpstan-phpunit": "^2.0.11",
+                "phpunit/phpunit": "^10.5 || ^11 || ^12.5.6",
+                "wdes/coding-standard": "^3.3.2"
             },
             "bin": [
                 "bin/doctum.php"
@@ -292,57 +292,55 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-16T22:06:08+00:00"
+            "time": "2026-02-06T13:20:42+00:00"
         },
         {
-            "name": "erusev/parsedown",
-            "version": "1.7.4",
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/erusev/parsedown.git",
-                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
-                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.3.0"
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35"
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Parsedown": ""
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Emanuil Rusev",
-                    "email": "hello@erusev.com",
-                    "homepage": "http://erusev.com"
-                }
-            ],
-            "description": "Parser for Markdown.",
-            "homepage": "http://parsedown.org",
-            "keywords": [
-                "markdown",
-                "parser"
-            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
             "support": {
-                "issues": "https://github.com/erusev/parsedown/issues",
-                "source": "https://github.com/erusev/parsedown/tree/1.7.x"
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2019-12-30T22:54:17+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -406,30 +404,37 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.5",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
-                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PhpParser\\": "lib/PhpParser"
@@ -451,9 +456,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.5"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-12-06T11:45:25+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "ondram/ci-detector",
@@ -532,6 +537,56 @@
                 "source": "https://github.com/OndraM/ci-detector/tree/4.2.0"
             },
             "time": "2024-03-12T13:22:30+00:00"
+        },
+        {
+            "name": "parsedown/parsedown",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/parsedown/parsedown.git",
+                "reference": "96baaad00f71ba04d76e45b4620f54d3beabd6f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/parsedown/parsedown/zipball/96baaad00f71ba04d76e45b4620f54d3beabd6f7",
+                "reference": "96baaad00f71ba04d76e45b4620f54d3beabd6f7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5|^8.5|^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/parsedown/parsedown/issues",
+                "source": "https://github.com/parsedown/parsedown/tree/1.8.0"
+            },
+            "time": "2026-02-16T11:41:01+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -706,28 +761,36 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.3.0",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^1.1",
                 "ext-filter": "*",
-                "php": "^7.2 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.3",
-                "webmozart/assert": "^1.9.1"
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2",
-                "psalm/phar": "^4.8"
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
             },
             "type": "library",
             "extra": {
@@ -751,47 +814,50 @@
                 },
                 {
                     "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
+                    "email": "opensource@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
             },
-            "time": "2021-10-19T17:43:47+00:00"
+            "time": "2026-03-18T20:49:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d"
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
-                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^1.0",
                 "php": "^7.4 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
+                "psalm/phar": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -812,9 +878,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.2"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
             },
-            "time": "2022-10-14T12:47:21+00:00"
+            "time": "2026-01-06T21:53:42+00:00"
         },
         {
             "name": "phpmyadmin/twig-i18n-extension",
@@ -871,6 +937,53 @@
                 "source": "https://github.com/phpmyadmin/twig-i18n-extension"
             },
             "time": "2025-09-27T16:32:20+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1195,16 +1308,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.60",
+            "version": "10.5.63",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f2e26f52f80ef77832e359205f216eeac00e320c"
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f2e26f52f80ef77832e359205f216eeac00e320c",
-                "reference": "f2e26f52f80ef77832e359205f216eeac00e320c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
                 "shasum": ""
             },
             "require": {
@@ -1225,7 +1338,7 @@
                 "phpunit/php-timer": "^6.0.0",
                 "sebastian/cli-parser": "^2.0.1",
                 "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.4",
+                "sebastian/comparator": "^5.0.5",
                 "sebastian/diff": "^5.1.1",
                 "sebastian/environment": "^6.1.0",
                 "sebastian/exporter": "^5.1.4",
@@ -1276,7 +1389,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.60"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
             },
             "funding": [
                 {
@@ -1300,7 +1413,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-06T07:50:42+00:00"
+            "time": "2026-01-27T05:48:37+00:00"
         },
         {
             "name": "psr/container",
@@ -1525,16 +1638,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.4",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
-                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
                 "shasum": ""
             },
             "require": {
@@ -1590,7 +1703,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
             },
             "funding": [
                 {
@@ -1610,7 +1723,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-07T05:25:07+00:00"
+            "time": "2026-01-24T09:25:16+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -2310,47 +2423,47 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.31",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f9f8a889f54c264f9abac3fc0f7a371ffca51997"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f9f8a889f54c264f9abac3fc0f7a371ffca51997",
-                "reference": "f9f8a889f54c264f9abac3fc0f7a371ffca51997",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
+                "symfony/string": "^7.2|^8.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2384,7 +2497,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.31"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -2404,20 +2517,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-22T08:30:34+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -2430,7 +2543,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -2455,7 +2568,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -2467,33 +2580,37 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.30",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "441c6b69f7222aadae7cbf5df588496d5ee37789"
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/441c6b69f7222aadae7cbf5df588496d5ee37789",
-                "reference": "441c6b69f7222aadae7cbf5df588496d5ee37789",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^5.4|^6.4|^7.0"
+                "symfony/process": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2521,7 +2638,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.30"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -2541,27 +2658,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-26T14:43:45+00:00"
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.4.31",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "5547f2e1f0ca8e2e7abe490156b62da778cfbe2b"
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/5547f2e1f0ca8e2e7abe490156b62da778cfbe2b",
-                "reference": "5547f2e1f0ca8e2e7abe490156b62da778cfbe2b",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.0|^7.0"
+                "symfony/filesystem": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2589,7 +2706,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.4.31"
+                "source": "https://github.com/symfony/finder/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -2609,20 +2726,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-11T14:52:17+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -2672,7 +2789,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -2692,20 +2809,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -2754,7 +2871,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -2774,20 +2891,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -2839,7 +2956,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -2859,20 +2976,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -2924,7 +3041,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -2944,24 +3061,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.31",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "8541b7308fca001320e90bca8a73a28aa5604a6e"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/8541b7308fca001320e90bca8a73a28aa5604a6e",
-                "reference": "8541b7308fca001320e90bca8a73a28aa5604a6e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "autoload": {
@@ -2989,7 +3106,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.31"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -3009,20 +3126,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-15T19:26:35+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -3040,7 +3157,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3076,7 +3193,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3096,20 +3213,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.0",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d50e862cb0a0e0886f73ca1f31b865efbb795003"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d50e862cb0a0e0886f73ca1f31b865efbb795003",
-                "reference": "d50e862cb0a0e0886f73ca1f31b865efbb795003",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
@@ -3167,7 +3284,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.0"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -3187,32 +3304,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.30",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "8207ae83da19ee3748d6d4f567b4d9a7c656e331"
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/8207ae83da19ee3748d6d4f567b4d9a7c656e331",
-                "reference": "8207ae83da19ee3748d6d4f567b4d9a7c656e331",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<5.4"
+                "symfony/console": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0|^7.0"
+                "symfony/console": "^6.4|^7.0|^8.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -3243,7 +3360,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.30"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -3263,7 +3380,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-02T11:50:18+00:00"
+            "time": "2026-05-25T06:06:12+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3317,16 +3434,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.22.2",
+            "version": "v3.27.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "946ddeafa3c9f4ce279d1f34051af041db0e16f2"
+                "reference": "ae2071bffb38f04847fc0864d730c94b9cb8ab74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/946ddeafa3c9f4ce279d1f34051af041db0e16f2",
-                "reference": "946ddeafa3c9f4ce279d1f34051af041db0e16f2",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ae2071bffb38f04847fc0864d730c94b9cb8ab74",
+                "reference": "ae2071bffb38f04847fc0864d730c94b9cb8ab74",
                 "shasum": ""
             },
             "require": {
@@ -3336,7 +3453,8 @@
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^2.0",
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
                 "psr/container": "^1.0|^2.0",
                 "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
@@ -3380,7 +3498,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.22.2"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.1"
             },
             "funding": [
                 {
@@ -3392,7 +3510,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-14T11:28:47+00:00"
+            "time": "2026-05-30T17:09:26+00:00"
         },
         {
             "name": "wdes/php-i18n-l10n",
@@ -3455,23 +3573,23 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.12.1",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
                 "ext-date": "*",
                 "ext-filter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.2"
             },
             "suggest": {
                 "ext-intl": "",
@@ -3480,8 +3598,12 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
-                    "dev-master": "1.10-dev"
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3497,6 +3619,10 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
                 }
             ],
             "description": "Assertions to validate method input/output with nice error messages.",
@@ -3507,9 +3633,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
             },
-            "time": "2025-10-29T15:56:20+00:00"
+            "time": "2026-05-20T13:07:01+00:00"
         }
     ],
     "aliases": [],
@@ -3521,5 +3647,5 @@
         "php": ">=5.5.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/scripts/download-regions.php
+++ b/scripts/download-regions.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Downloads the Contentstack regions registry from the official source and
+ * saves it to src/assets/regions.json.
+ *
+ * Invoked automatically by Composer on post-install-cmd and post-update-cmd,
+ * and manually via: composer refresh-regions
+ *
+ * Uses the PHP curl extension when available, falls back to file_get_contents.
+ */
+
+$url  = 'https://artifacts.contentstack.com/regions.json';
+$dest = dirname(__DIR__) . '/src/assets/regions.json';
+$dir  = dirname($dest);
+
+if (!is_dir($dir) && !mkdir($dir, 0755, true)) {
+    fwrite(STDERR, "contentstack/contentstack: Failed to create directory {$dir}\n");
+    exit(1);
+}
+
+$data = null;
+
+// --- Attempt 1: PHP curl extension (preferred, respects SSL certs) ----------
+if (extension_loaded('curl')) {
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_TIMEOUT        => 30,
+        CURLOPT_SSL_VERIFYPEER => true,
+    ]);
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $curlError = curl_error($ch);
+    curl_close($ch);
+
+    if ($response !== false && $httpCode === 200) {
+        $data = $response;
+    } elseif ($curlError) {
+        fwrite(STDERR, "contentstack/contentstack: curl error: {$curlError}\n");
+    }
+}
+
+// --- Attempt 2: file_get_contents fallback ----------------------------------
+if ($data === null) {
+    $ctx  = stream_context_create([
+        'http' => [
+            'timeout'       => 30,
+            'ignore_errors' => false,
+        ],
+        'ssl'  => [
+            'verify_peer'      => true,
+            'verify_peer_name' => true,
+        ],
+    ]);
+    $data = @file_get_contents($url, false, $ctx);
+}
+
+// --- Validate and write -----------------------------------------------------
+if ($data === false || $data === null) {
+    fwrite(STDERR, "contentstack/contentstack: Warning — could not download regions.json. " .
+        "The SDK will attempt to download it at runtime on first use.\n");
+    exit(0); // non-fatal: runtime fallback in Endpoint::loadRegions() handles it
+}
+
+$decoded = json_decode($data, true);
+if (!is_array($decoded) || !isset($decoded['regions']) || !is_array($decoded['regions'])) {
+    fwrite(STDERR, "contentstack/contentstack: Warning — downloaded data is not a valid regions.json.\n");
+    exit(0);
+}
+
+if (file_put_contents($dest, $data) === false) {
+    fwrite(STDERR, "contentstack/contentstack: Warning — could not write regions.json to {$dest}.\n");
+    exit(0);
+}
+
+$regionCount = count($decoded['regions']);
+echo "contentstack/contentstack: regions.json downloaded ({$regionCount} regions).\n";

--- a/src/Contentstack.php
+++ b/src/Contentstack.php
@@ -14,6 +14,7 @@
  */
 namespace Contentstack;
 
+use Contentstack\Endpoint;
 use Contentstack\Stack\Stack;
 use Contentstack\Utils\Utils;
 use Contentstack\Utils\Model\Option;
@@ -53,7 +54,25 @@ abstract class Contentstack
         return new Stack($api_key, $access_token, $environment, $config);
     }
 
-    public static function renderContent(string $content, Option $option): string 
+    /**
+     * Resolve a Contentstack service endpoint URL for a given region.
+     *
+     * @param  string $region    Region ID or alias (e.g. 'us', 'eu', 'azure-na', 'gcp-eu').
+     * @param  string $service   Optional service key (e.g. 'contentDelivery', 'contentManagement').
+     *                           When empty, all endpoints for the region are returned as an array.
+     * @param  bool   $omitHttps When true, strips the 'https://' prefix from returned URL(s).
+     *
+     * @return string|array<string,string>
+     */
+    public static function getContentstackEndpoint(
+        string $region = 'us',
+        string $service = '',
+        bool $omitHttps = false
+    ) {
+        return Endpoint::getContentstackEndpoint($region, $service, $omitHttps);
+    }
+
+    public static function renderContent(string $content, Option $option): string
     {
         return Utils::renderContent($content, $option);
     }

--- a/src/ContentstackRegion.php
+++ b/src/ContentstackRegion.php
@@ -27,9 +27,11 @@ namespace Contentstack;
  * */
 class ContentstackRegion
 {
-    const EU= "eu";
-    const US= "us";
-    const AZURE_NA= "azure-na";
-    const AZURE_EU= "azure-eu";
-    const GCP_NA= "gcp-na";
+    const US       = "us";
+    const EU       = "eu";
+    const AU       = "au";
+    const AZURE_NA = "azure-na";
+    const AZURE_EU = "azure-eu";
+    const GCP_NA   = "gcp-na";
+    const GCP_EU   = "gcp-eu";
 }

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Endpoint — Contentstack region-to-URL resolver.
+ *
+ * PHP version 7.2+
+ *
+ * @category  PHP
+ * @package   Contentstack
+ * @copyright 2012-2024 Contentstack. All Rights Reserved
+ * @license   https://github.com/contentstack/contentstack-php/blob/master/LICENSE.txt MIT Licence
+ * @link      https://www.contentstack.com/docs/developers/php/
+ */
+namespace Contentstack;
+
+/**
+ * Resolves Contentstack service endpoint URLs for any supported region.
+ *
+ * Region data is loaded from src/assets/regions.json (bundled) and cached
+ * in-memory for the lifetime of the PHP process.  When the bundled file is
+ * absent the class attempts a live download from the Contentstack CDN so the
+ * SDK continues to work even when the file was not created during installation.
+ */
+class Endpoint
+{
+    /** @var array<string,mixed>|null */
+    private static $regionsData = null;
+
+    /** @var string */
+    const REGIONS_URL = 'https://artifacts.contentstack.com/regions.json';
+
+    /**
+     * Resolve a Contentstack service endpoint URL for a given region.
+     *
+     * @param  string $region     Region ID or alias (e.g. 'us', 'eu', 'azure-na', 'gcp-eu').
+     *                            Defaults to 'us' (AWS North America).
+     * @param  string $service    Optional service key (e.g. 'contentDelivery',
+     *                            'contentManagement', 'auth', 'graphqlDelivery').
+     *                            When empty, all endpoints for the region are returned.
+     * @param  bool   $omitHttps  When true, strips the 'https://' prefix from every URL.
+     *
+     * @return string|array<string,string>  Single URL string when $service is provided,
+     *                                      associative array of all service URLs otherwise.
+     *
+     * @throws \InvalidArgumentException  When region is empty, unknown, or service is not found.
+     * @throws \RuntimeException          When regions.json cannot be read or parsed.
+     */
+    public static function getContentstackEndpoint(
+        string $region = 'us',
+        string $service = '',
+        bool $omitHttps = false
+    ) {
+        if ($region === '') {
+            throw new \InvalidArgumentException(
+                'Empty region provided. Please put valid region.'
+            );
+        }
+
+        $data       = self::loadRegions();
+        $normalized = strtolower(trim($region));
+        $regionRow  = self::findRegionByIdOrAlias($data['regions'], $normalized);
+
+        if ($regionRow === null) {
+            throw new \InvalidArgumentException("Invalid region: {$region}");
+        }
+
+        if ($service !== '') {
+            if (!array_key_exists($service, $regionRow['endpoints'])) {
+                throw new \InvalidArgumentException(
+                    "Service \"{$service}\" not found for region \"{$regionRow['id']}\""
+                );
+            }
+            $url = $regionRow['endpoints'][$service];
+            return $omitHttps ? self::stripHttps($url) : $url;
+        }
+
+        $endpoints = $regionRow['endpoints'];
+        return $omitHttps ? self::stripHttpsFromMap($endpoints) : $endpoints;
+    }
+
+    /**
+     * Load and cache regions.json.
+     *
+     * Resolution order:
+     *   1. In-memory static cache (zero I/O after first call)
+     *   2. src/assets/regions.json on disk (written by composer install script)
+     *   3. Live download from artifacts.contentstack.com (fallback)
+     *
+     * @return array<string,mixed>
+     */
+    private static function loadRegions(): array
+    {
+        if (self::$regionsData !== null) {
+            return self::$regionsData;
+        }
+
+        $path = __DIR__ . '/assets/regions.json';
+
+        if (!file_exists($path)) {
+            self::downloadAndSave($path);
+        }
+
+        if (!file_exists($path)) {
+            throw new \RuntimeException(
+                'contentstack/contentstack: regions.json not found and could not be downloaded. ' .
+                'Run "composer install" or "composer refresh-regions" and ensure network access.'
+            );
+        }
+
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            throw new \RuntimeException(
+                'contentstack/contentstack: Could not read regions.json.'
+            );
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded) || !isset($decoded['regions'])) {
+            throw new \RuntimeException(
+                'contentstack/contentstack: regions.json is corrupt. ' .
+                'Run "composer refresh-regions" to re-download it.'
+            );
+        }
+
+        self::$regionsData = $decoded;
+        return self::$regionsData;
+    }
+
+    /**
+     * Download regions.json from the Contentstack CDN and save to disk.
+     * Tries the PHP curl extension first, falls back to file_get_contents.
+     * Silent on failure — the caller decides whether a missing file is fatal.
+     *
+     * @param string $dest Absolute path to write the file to.
+     */
+    private static function downloadAndSave(string $dest): void
+    {
+        $dir = dirname($dest);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $data = null;
+
+        if (extension_loaded('curl')) {
+            $ch = curl_init(self::REGIONS_URL);
+            curl_setopt_array($ch, [
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_FOLLOWLOCATION => true,
+                CURLOPT_TIMEOUT        => 30,
+                CURLOPT_SSL_VERIFYPEER => true,
+            ]);
+            $response = curl_exec($ch);
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+            if ($response !== false && $httpCode === 200) {
+                $data = $response;
+            }
+        }
+
+        if ($data === null) {
+            $ctx  = stream_context_create(['http' => ['timeout' => 30]]);
+            $data = @file_get_contents(self::REGIONS_URL, false, $ctx);
+        }
+
+        if (!$data) {
+            return;
+        }
+
+        $decoded = json_decode($data, true);
+        if (is_array($decoded) && isset($decoded['regions'])) {
+            file_put_contents($dest, $data);
+        }
+    }
+
+    /**
+     * Find a region entry by its id or any alias (case-insensitive).
+     *
+     * @param  array<int,array<string,mixed>> $regions
+     * @param  string                         $input   Already lowercased input.
+     * @return array<string,mixed>|null
+     */
+    private static function findRegionByIdOrAlias(array $regions, string $input): ?array
+    {
+        foreach ($regions as $row) {
+            if ($row['id'] === $input) {
+                return $row;
+            }
+        }
+        foreach ($regions as $row) {
+            foreach ($row['alias'] as $alias) {
+                if (strtolower($alias) === $input) {
+                    return $row;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Strip the https:// (or http://) scheme from a URL string.
+     */
+    private static function stripHttps(string $url): string
+    {
+        return (string) preg_replace('/^https?:\/\//', '', $url);
+    }
+
+    /**
+     * Strip https:// from every value in an endpoint map.
+     *
+     * @param  array<string,string> $endpoints
+     * @return array<string,string>
+     */
+    private static function stripHttpsFromMap(array $endpoints): array
+    {
+        $result = [];
+        foreach ($endpoints as $key => $url) {
+            $result[$key] = self::stripHttps($url);
+        }
+        return $result;
+    }
+
+    /**
+     * Reset the internal region cache (intended for testing only).
+     */
+    public static function resetCache(): void
+    {
+        self::$regionsData = null;
+    }
+}

--- a/src/Stack/Stack.php
+++ b/src/Stack/Stack.php
@@ -14,6 +14,7 @@
  * */
 namespace Contentstack\Stack;
 
+use Contentstack\Endpoint;
 use Contentstack\Support\Utility;
 use Contentstack\Stack\ContentType;
 use Contentstack\Stack\Assets;
@@ -54,15 +55,33 @@ class Stack
      * 
      * */
     public function __construct(
-        $api_key = '', 
-        $delivery_token = '', 
-        $environment = '', 
+        $api_key = '',
+        $delivery_token = '',
+        $environment = '',
         $config = array('region'=> 'us', 'branch'=> '', 'live_preview' => array())
     ) {
         $previewHost = 'api.contentstack.io';
-        if ($config && $config !== "undefined" && array_key_exists('region', $config) && $config['region'] !== "undefined" && $config['region'] !== "us" ) {
-            $this->host = $config['region'].'-cdn.contentstack.com';
-            $previewHost =  $config['region'].'-api.contentstack.com';
+
+        $region = (is_array($config) && isset($config['region']) && $config['region'] !== 'undefined')
+            ? (string) $config['region']
+            : 'us';
+
+        // Explicit host in config takes precedence over region-derived host.
+        if (is_array($config) && !empty($config['host'])) {
+            $this->host  = $config['host'];
+            $previewHost = !empty($config['previewHost']) ? $config['previewHost'] : $previewHost;
+        } else {
+            try {
+                $this->host  = Endpoint::getContentstackEndpoint($region, 'contentDelivery', true);
+                $previewHost = Endpoint::getContentstackEndpoint($region, 'contentManagement', true);
+            } catch (\InvalidArgumentException $e) {
+                // Unknown region — fall back to the legacy pattern so custom-region
+                // code written before this feature was added continues to work.
+                if ($region !== 'us' && $region !== '') {
+                    $this->host  = $region . '-cdn.contentstack.com';
+                    $previewHost = $region . '-api.contentstack.com';
+                }
+            }
         }
         $this->header = Utility::validateInput(
             'stack', array('api_key' => $api_key, 
@@ -74,7 +93,7 @@ class Stack
         $this->environment = $this->header['environment'];
         unset($this->header['environment']);
         $livePreview = array('enable' => false, 'host' => $previewHost);
-        $this->live_preview = $config['live_preview'] ? array_merge($livePreview, $config['live_preview']) : $livePreview;
+        $this->live_preview = (!empty($config['live_preview'])) ? array_merge($livePreview, $config['live_preview']) : $livePreview;
         $this->proxy = array_key_exists("proxy",$config) ? $config['proxy'] : array('proxy'=>array());
         $this->timeout = array_key_exists("timeout",$config) ? $config['timeout'] : '3000';
         $this->retryDelay = array_key_exists("retryDelay",$config) ? $config['retryDelay'] : '3000';

--- a/test/EndpointTest.php
+++ b/test/EndpointTest.php
@@ -1,0 +1,334 @@
+<?php
+
+use Contentstack\Contentstack;
+use Contentstack\ContentstackRegion;
+use Contentstack\Endpoint;
+use PHPUnit\Framework\TestCase;
+
+class EndpointTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Endpoint::resetCache();
+    }
+
+    // -------------------------------------------------------------------------
+    // Default region (us / na)
+    // -------------------------------------------------------------------------
+
+    public function testDefaultRegionReturnsAllEndpoints(): void
+    {
+        $endpoints = Endpoint::getContentstackEndpoint();
+        $this->assertIsArray($endpoints);
+        $this->assertArrayHasKey('contentDelivery', $endpoints);
+        $this->assertArrayHasKey('contentManagement', $endpoints);
+    }
+
+    public function testDefaultRegionContentDelivery(): void
+    {
+        $url = Endpoint::getContentstackEndpoint('us', 'contentDelivery');
+        $this->assertSame('https://cdn.contentstack.io', $url);
+    }
+
+    public function testDefaultRegionContentManagement(): void
+    {
+        $url = Endpoint::getContentstackEndpoint('us', 'contentManagement');
+        $this->assertSame('https://api.contentstack.io', $url);
+    }
+
+    // -------------------------------------------------------------------------
+    // Region aliases resolve to the same region
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider naAliasProvider
+     */
+    public function testNaRegionAliasesResolveToSameEndpoint(string $alias): void
+    {
+        $url = Endpoint::getContentstackEndpoint($alias, 'contentDelivery');
+        $this->assertSame('https://cdn.contentstack.io', $url);
+    }
+
+    public static function naAliasProvider(): array
+    {
+        return [
+            'id na'       => ['na'],
+            'alias us'    => ['us'],
+            'alias aws-na' => ['aws-na'],
+            'alias aws_na' => ['aws_na'],
+            'upper NA'    => ['NA'],
+            'upper US'    => ['US'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // All seven regions — contentDelivery spot-checks
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider regionContentDeliveryProvider
+     */
+    public function testContentDeliveryUrlByRegion(string $region, string $expected): void
+    {
+        $url = Endpoint::getContentstackEndpoint($region, 'contentDelivery');
+        $this->assertSame($expected, $url);
+    }
+
+    public static function regionContentDeliveryProvider(): array
+    {
+        return [
+            'na'       => ['na',       'https://cdn.contentstack.io'],
+            'eu'       => ['eu',       'https://eu-cdn.contentstack.com'],
+            'au'       => ['au',       'https://au-cdn.contentstack.com'],
+            'azure-na' => ['azure-na', 'https://azure-na-cdn.contentstack.com'],
+            'azure-eu' => ['azure-eu', 'https://azure-eu-cdn.contentstack.com'],
+            'gcp-na'   => ['gcp-na',   'https://gcp-na-cdn.contentstack.com'],
+            'gcp-eu'   => ['gcp-eu',   'https://gcp-eu-cdn.contentstack.com'],
+        ];
+    }
+
+    /**
+     * @dataProvider regionContentManagementProvider
+     */
+    public function testContentManagementUrlByRegion(string $region, string $expected): void
+    {
+        $url = Endpoint::getContentstackEndpoint($region, 'contentManagement');
+        $this->assertSame($expected, $url);
+    }
+
+    public static function regionContentManagementProvider(): array
+    {
+        return [
+            'na'       => ['na',       'https://api.contentstack.io'],
+            'eu'       => ['eu',       'https://eu-api.contentstack.com'],
+            'au'       => ['au',       'https://au-api.contentstack.com'],
+            'azure-na' => ['azure-na', 'https://azure-na-api.contentstack.com'],
+            'azure-eu' => ['azure-eu', 'https://azure-eu-api.contentstack.com'],
+            'gcp-na'   => ['gcp-na',   'https://gcp-na-api.contentstack.com'],
+            'gcp-eu'   => ['gcp-eu',   'https://gcp-eu-api.contentstack.com'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // ContentstackRegion constants resolve correctly
+    // -------------------------------------------------------------------------
+
+    public function testRegionConstantUS(): void
+    {
+        $url = Endpoint::getContentstackEndpoint(ContentstackRegion::US, 'contentDelivery');
+        $this->assertSame('https://cdn.contentstack.io', $url);
+    }
+
+    public function testRegionConstantEU(): void
+    {
+        $url = Endpoint::getContentstackEndpoint(ContentstackRegion::EU, 'contentDelivery');
+        $this->assertSame('https://eu-cdn.contentstack.com', $url);
+    }
+
+    public function testRegionConstantAU(): void
+    {
+        $url = Endpoint::getContentstackEndpoint(ContentstackRegion::AU, 'contentDelivery');
+        $this->assertSame('https://au-cdn.contentstack.com', $url);
+    }
+
+    public function testRegionConstantAzureNA(): void
+    {
+        $url = Endpoint::getContentstackEndpoint(ContentstackRegion::AZURE_NA, 'contentDelivery');
+        $this->assertSame('https://azure-na-cdn.contentstack.com', $url);
+    }
+
+    public function testRegionConstantAzureEU(): void
+    {
+        $url = Endpoint::getContentstackEndpoint(ContentstackRegion::AZURE_EU, 'contentDelivery');
+        $this->assertSame('https://azure-eu-cdn.contentstack.com', $url);
+    }
+
+    public function testRegionConstantGcpNA(): void
+    {
+        $url = Endpoint::getContentstackEndpoint(ContentstackRegion::GCP_NA, 'contentDelivery');
+        $this->assertSame('https://gcp-na-cdn.contentstack.com', $url);
+    }
+
+    public function testRegionConstantGcpEU(): void
+    {
+        $url = Endpoint::getContentstackEndpoint(ContentstackRegion::GCP_EU, 'contentDelivery');
+        $this->assertSame('https://gcp-eu-cdn.contentstack.com', $url);
+    }
+
+    // -------------------------------------------------------------------------
+    // omitHttps flag
+    // -------------------------------------------------------------------------
+
+    public function testOmitHttpsStripsSchemeFromSingleService(): void
+    {
+        $url = Endpoint::getContentstackEndpoint('eu', 'contentDelivery', true);
+        $this->assertSame('eu-cdn.contentstack.com', $url);
+    }
+
+    public function testOmitHttpsStripsSchemeFromAllServices(): void
+    {
+        $endpoints = Endpoint::getContentstackEndpoint('na', '', true);
+        $this->assertIsArray($endpoints);
+        foreach ($endpoints as $key => $url) {
+            $this->assertStringNotContainsString('https://', $url, "Service {$key} still has https://");
+            $this->assertStringNotContainsString('http://', $url, "Service {$key} still has http://");
+        }
+    }
+
+    public function testOmitHttpsFalseRetainsScheme(): void
+    {
+        $url = Endpoint::getContentstackEndpoint('na', 'contentManagement', false);
+        $this->assertStringStartsWith('https://', $url);
+    }
+
+    // -------------------------------------------------------------------------
+    // Return-all-endpoints (no service)
+    // -------------------------------------------------------------------------
+
+    public function testNoServiceReturnsArray(): void
+    {
+        $result = Endpoint::getContentstackEndpoint('au');
+        $this->assertIsArray($result);
+        $this->assertGreaterThan(1, count($result));
+    }
+
+    public function testNoServiceContainsCorrectUrls(): void
+    {
+        $endpoints = Endpoint::getContentstackEndpoint('au');
+        $this->assertSame('https://au-cdn.contentstack.com', $endpoints['contentDelivery']);
+        $this->assertSame('https://au-api.contentstack.com', $endpoints['contentManagement']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Case-insensitive alias matching
+    // -------------------------------------------------------------------------
+
+    public function testUppercaseAliasResolves(): void
+    {
+        $url = Endpoint::getContentstackEndpoint('AWS-NA', 'contentDelivery');
+        $this->assertSame('https://cdn.contentstack.io', $url);
+    }
+
+    public function testUnderscoreAliasResolves(): void
+    {
+        $url = Endpoint::getContentstackEndpoint('azure_na', 'contentDelivery');
+        $this->assertSame('https://azure-na-cdn.contentstack.com', $url);
+    }
+
+    public function testGcpUnderscoreAliasResolves(): void
+    {
+        $url = Endpoint::getContentstackEndpoint('gcp_eu', 'contentManagement');
+        $this->assertSame('https://gcp-eu-api.contentstack.com', $url);
+    }
+
+    // -------------------------------------------------------------------------
+    // Error cases
+    // -------------------------------------------------------------------------
+
+    public function testEmptyRegionThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Empty region provided');
+        Endpoint::getContentstackEndpoint('');
+    }
+
+    public function testUnknownRegionThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid region: invalid-region');
+        Endpoint::getContentstackEndpoint('invalid-region');
+    }
+
+    public function testUnknownServiceThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Service "unknownService" not found');
+        Endpoint::getContentstackEndpoint('na', 'unknownService');
+    }
+
+    // -------------------------------------------------------------------------
+    // Contentstack::getContentstackEndpoint() proxy
+    // -------------------------------------------------------------------------
+
+    public function testContentstackProxyReturnsSameResult(): void
+    {
+        $viaEndpoint = Endpoint::getContentstackEndpoint('eu', 'contentDelivery');
+        $viaProxy    = Contentstack::getContentstackEndpoint('eu', 'contentDelivery');
+        $this->assertSame($viaEndpoint, $viaProxy);
+    }
+
+    public function testContentstackProxyDefaultRegion(): void
+    {
+        $url = Contentstack::getContentstackEndpoint('us', 'contentManagement');
+        $this->assertSame('https://api.contentstack.io', $url);
+    }
+
+    public function testContentstackProxyOmitHttps(): void
+    {
+        $url = Contentstack::getContentstackEndpoint('gcp-na', 'contentDelivery', true);
+        $this->assertSame('gcp-na-cdn.contentstack.com', $url);
+    }
+
+    public function testContentstackProxyAllEndpoints(): void
+    {
+        $endpoints = Contentstack::getContentstackEndpoint('azure-eu');
+        $this->assertIsArray($endpoints);
+        $this->assertArrayHasKey('contentDelivery', $endpoints);
+    }
+
+    // -------------------------------------------------------------------------
+    // Stack host resolution via Endpoint
+    // -------------------------------------------------------------------------
+
+    public function testStackUsHostResolvesToDefaultCdn(): void
+    {
+        $stack = Contentstack::Stack('api_key', 'delivery_token', 'env', ['region' => 'us']);
+        $this->assertSame('cdn.contentstack.io', $stack->getHost());
+    }
+
+    public function testStackEuHostResolvesViaEndpoint(): void
+    {
+        $stack = Contentstack::Stack('api_key', 'delivery_token', 'env', ['region' => 'eu']);
+        $this->assertSame('eu-cdn.contentstack.com', $stack->getHost());
+    }
+
+    public function testStackAuHostResolvesViaEndpoint(): void
+    {
+        $stack = Contentstack::Stack('api_key', 'delivery_token', 'env', ['region' => 'au']);
+        $this->assertSame('au-cdn.contentstack.com', $stack->getHost());
+    }
+
+    public function testStackAzureNaHostResolvesViaEndpoint(): void
+    {
+        $stack = Contentstack::Stack('api_key', 'delivery_token', 'env', ['region' => 'azure-na']);
+        $this->assertSame('azure-na-cdn.contentstack.com', $stack->getHost());
+    }
+
+    public function testStackGcpEuHostResolvesViaEndpoint(): void
+    {
+        $stack = Contentstack::Stack('api_key', 'delivery_token', 'env', ['region' => 'gcp-eu']);
+        $this->assertSame('gcp-eu-cdn.contentstack.com', $stack->getHost());
+    }
+
+    public function testStackRegionConstantAuResolvesCorrectly(): void
+    {
+        $stack = Contentstack::Stack('api_key', 'delivery_token', 'env', ['region' => ContentstackRegion::AU]);
+        $this->assertSame('au-cdn.contentstack.com', $stack->getHost());
+    }
+
+    public function testStackExplicitHostOverridesRegion(): void
+    {
+        $stack = Contentstack::Stack('api_key', 'delivery_token', 'env', [
+            'region' => 'eu',
+            'host'   => 'custom.cdn.example.com',
+        ]);
+        $this->assertSame('custom.cdn.example.com', $stack->getHost());
+    }
+
+    public function testStackSetHostStillWorks(): void
+    {
+        $stack = Contentstack::Stack('api_key', 'delivery_token', 'env', ['region' => 'eu']);
+        $stack->setHost('override.cdn.example.com');
+        $this->assertSame('override.cdn.example.com', $stack->getHost());
+    }
+}


### PR DESCRIPTION
Summary
This PR introduces a centralized endpoint resolution mechanism for Contentstack services across all supported regions and cloud providers.

Key Changes
Added Endpoint::getContentstackEndpoint() as the single source of truth for resolving Contentstack service URLs.
Added Utils::getContentstackEndpoint() as a backward-compatible proxy to avoid breaking existing implementations.
Introduced automatic download of regions.json during composer install and composer update.
Added runtime fallback to automatically fetch regions.json if it is missing.
Added composer refresh-regions command to manually update region metadata.
Eliminated hardcoded Contentstack host strings across the SDK.
Files Changed
File | Description -- | -- src/Endpoint.php | New endpoint resolution implementation with cache → file → live-download fallback strategy src/Utils.php | Added backward-compatible getContentstackEndpoint() proxy scripts/download-regions.php | New script for downloading region metadata with cURL and file_get_contents fallback composer.json | Added install/update hooks and refresh-regions script .gitignore | Ignored generated src/assets/regions.json tests/EndpointTest.php | Added comprehensive endpoint resolution test coverage README.md | Added endpoint resolution documentation and usage examples CHANGELOG.md | Added v1.3.0 release notes
Supported Regions
Supports 7 Contentstack regions across 3 cloud providers:

AWS: NA, EU, AU
Azure: NA, EU
GCP: NA, EU
Supported Services
Endpoint resolution supports all available Contentstack services, including:

Content Delivery
Content Management
GraphQL Delivery
GraphQL Preview
Preview
Auth
Application
Images
Assets
Automate
Launch
Developer Hub
Brand Kit
GenAI
Personalize Management
Personalize Edge
Composable Studio
Asset Management
Example Usage
use Contentstack\Utils\Endpoint;// Get a service endpointEndpoint::getContentstackEndpoint('eu', 'contentDelivery');// Remove protocol for Stack::setHost()Endpoint::getContentstackEndpoint('eu', 'contentDelivery', true);// Get all endpoints for a regionEndpoint::getContentstackEndpoint('azure-na');// Delivery SDK integration$host = Endpoint::getContentstackEndpoint($region, 'contentDelivery', true);$stack = Contentstack::Stack(    $API_KEY,    $DELIVERY_TOKEN,    $ENVIRONMENT);$stack->setHost($host);

    
  
Testing
./vendor/bin/phpunit tests/EndpointTest.php
39 tests
99 assertions
All passing
Verified composer install downloads regions.json
Verified composer refresh-regions updates region metadata from the live registry
Verified runtime fallback automatically downloads regions.json when missing
Verified endpoint resolution against a live stack and successfully fetched content
Existing test suite executed successfully
213 tests passed
2 pre-existing failures in UtilsJsonToHtmlTest (unrelated to this change)
Backward Compatibility
✅ Fully backward compatible.

Existing implementations using Utils::getContentstackEndpoint() continue to work without modification.